### PR TITLE
Fixed Spaces encoding in directory and filenames

### DIFF
--- a/TwitchLeecher/TwitchLeecher.Gui/Services/DialogService.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/Services/DialogService.cs
@@ -2,6 +2,7 @@
 using Avalonia.Input;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
+using Microsoft.AspNetCore.Http;
 using TwitchLeecher.Core.Models;
 using TwitchLeecher.Gui.Interfaces;
 using TwitchLeecher.Gui.Types;
@@ -72,7 +73,7 @@ namespace TwitchLeecher.Gui.Services
             });
             if (picker.Any())
             {
-                dialogCompleteCallback(false, picker.First().Path.AbsolutePath);
+                dialogCompleteCallback(false, Uri.UnescapeDataString(picker.First().Path.LocalPath));
                 return;
             }
 

--- a/TwitchLeecher/TwitchLeecher.Gui/ViewModels/DownloadViewModel.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/ViewModels/DownloadViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
 using ReactiveUI;
 using TwitchLeecher.Core.Models;
 using TwitchLeecher.Gui.Interfaces;
@@ -10,14 +11,13 @@ using TwitchLeecher.Shared.Extensions;
 
 namespace TwitchLeecher.Gui.ViewModels
 {
-    public class DownloadViewModel : ViewModelBase
+    public partial class DownloadViewModel : ViewModelBase
     {
         #region Fields
 
         private DownloadParameters _downloadParams;
         private bool _useCustomFilename;
 
-        private ICommand _chooseCommand;
         private ICommand _downloadCommand;
         private ICommand _cancelCommand;
 
@@ -174,20 +174,6 @@ namespace TwitchLeecher.Gui.ViewModels
                 FirePropertyChanged(nameof(CropEndSeconds));
             }
         }
-
-        public ICommand ChooseCommand
-        {
-            get
-            {
-                if (_chooseCommand == null)
-                {
-                    _chooseCommand = new DelegateCommand(Choose);
-                }
-
-                return _chooseCommand;
-            }
-        }
-
         public ICommand DownloadCommand
         {
             get
@@ -218,6 +204,7 @@ namespace TwitchLeecher.Gui.ViewModels
 
         #region Methods
 
+        [RelayCommand]
         private void Choose()
         {
             try


### PR DESCRIPTION
Regarding #19, Directory (and Files) with spaces in the name can now be created. 
This pull-request will be merged when I got the chance to test this under Windows, I only tested in on Linux.

After mergin this PR, I will publish a new release containing this an #18 fix.