### PR TITLE
Fix opening in external player

### DIFF
--- a/TwitchLeecher/TwitchLeecher.Core/Models/Preferences.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/Preferences.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using TwitchLeecher.Core.Enums;
 using TwitchLeecher.Shared.Helpers;
 using TwitchLeecher.Shared.IO;
@@ -227,9 +228,11 @@ namespace TwitchLeecher.Core.Models
                     {
                         AddError(currentProperty, "Please specify an external player!");
                     }
-                    else if (!_miscExternalPlayer.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                    // skip executability check for linux: no built-in functionality to check permissions
+                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
+                             && !_miscExternalPlayer.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                     {
-                        AddError(currentProperty, "Filename must be an executable!");
+                        AddError(currentProperty, "File must be an executable!");
                     }
                     else if (!File.Exists(_miscExternalPlayer))
                     {

--- a/TwitchLeecher/TwitchLeecher.Gui/Services/DialogService.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/Services/DialogService.cs
@@ -136,15 +136,18 @@ namespace TwitchLeecher.Gui.Services
                 SuggestedStartLocation =
                     await window.StorageProvider.TryGetFolderFromPathAsync(folder),
                 FileTypeFilter = new[]
-                    { new FilePickerFileType(filter.Name) { Patterns = new[] { $"*.{filter.Extension}" } } }
+                {
+                    // does this also work on supported windows versions?
+                    new FilePickerFileType(filter.Name) { MimeTypes = new[] { "application/x-executable" } }
+                }
             });
             if (result.Any())
             {
-                dialogCompleteCallback(true, result.First().Path.AbsolutePath);
+                dialogCompleteCallback(false, result.First().Path.AbsolutePath);
                 return;
             }
 
-            dialogCompleteCallback(false, null);
+            dialogCompleteCallback(true, null);
         }
 
         public void ShowUpdateInfoDialog(UpdateInfo updateInfo)

--- a/TwitchLeecher/TwitchLeecher.Gui/ViewModels/SearchResultViewModel.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/ViewModels/SearchResultViewModel.cs
@@ -158,7 +158,15 @@ namespace TwitchLeecher.Gui.ViewModels
                 }
                 else
                 {
-                    Process.Start(video.Url.ToString());
+                    // Do not execute any string as command
+                    if (!video.Url.ToString().StartsWith("https://")) {
+                        throw new Exception("Unsupported video URL");
+                    }
+                    
+                    Process.Start(new ProcessStartInfo(video.Url.ToString()) {
+                        UseShellExecute = true,
+                        Verb = "open"
+                    });
                 }
             }
             catch (Exception ex)
@@ -235,17 +243,6 @@ namespace TwitchLeecher.Gui.ViewModels
             {
                 _dialogService.ShowAndLogException(ex);
             }
-        }
-
-        [RelayCommand]
-        private void OpenInBrowser(Uri url)
-        {
-            var psi = new ProcessStartInfo($"https://twitch.tv" + url.AbsolutePath)
-            {
-                UseShellExecute = true,
-                Verb = "open"
-            };
-            Process.Start(psi);
         }
 
         private TwitchVideoQuality GetSelectedQuality(List<TwitchVideoQuality> qualities, DefaultQuality defaultQuality)

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/SearchResultView.axaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/SearchResultView.axaml
@@ -59,8 +59,8 @@
                             <Grid Cursor="Hand">
                                 <Canvas>
                                     <Button
-                                        Command="{Binding $parent[UserControl].((viewModels:SearchResultViewModel)DataContext).OpenInBrowserCommand}"
-                                        CommandParameter="{Binding Url}">
+                                        Command="{Binding $parent[UserControl].((viewModels:SearchResultViewModel)DataContext).ViewCommand}"
+                                        CommandParameter="{Binding Id}">
                                         <Image Source="{Binding Thumbnail^}"
                                                Stretch="Fill" />
                                     </Button>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/SearchResultView.axaml.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/SearchResultView.axaml.cs
@@ -14,11 +14,5 @@ namespace TwitchLeecher.Gui.Views
         }
 
         #endregion Constructors
-
-        private void InputElement_OnPointerPressed(object sender, PointerPressedEventArgs e)
-        {
-            var viewModel = (SearchResultViewModel)DataContext;
-            viewModel!.ViewCommand.Execute(null);
-        }
     }
 }


### PR DESCRIPTION
The file chooser dialog will show non-exe executable files. Also corrected the cancel parameter's usage so that the selection gets saved to configuration.

Needs testing on windows, whether it supports the used mime type.

fixes #62