### PR TITLE
Fix download status in downloads menu

### DIFF
--- a/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideoDownload.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideoDownload.cs
@@ -58,7 +58,8 @@ namespace TwitchLeecher.Core.Models
             }
             private set
             {
-                _downloadState = value;
+                SetProperty(ref _downloadState, value);
+
                 FirePropertyChanged(nameof(IsDone));
                 FirePropertyChanged(nameof(CanRetry));
                 FirePropertyChanged(nameof(Status));

--- a/TwitchLeecher/TwitchLeecher.Core/TwitchLeecher.Core.csproj
+++ b/TwitchLeecher/TwitchLeecher.Core/TwitchLeecher.Core.csproj
@@ -16,7 +16,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.0-beta1" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.2" />
     <PackageReference Include="Ninject" Version="4.0.0-beta.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.118" />

--- a/TwitchLeecher/TwitchLeecher.Gui/TwitchLeecher.Gui.csproj
+++ b/TwitchLeecher/TwitchLeecher.Gui/TwitchLeecher.Gui.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <AvaloniaResource Include="Assets\**"/>
+        <AvaloniaResource Include="Assets\**" />
     </ItemGroup>
     <ItemGroup>
         <Compile Update="Views\AuthView.axaml.cs">
@@ -121,19 +121,19 @@
     </ItemGroup>
 
     <ItemGroup>
-        <AdditionalFiles Include="Views\AuthView.axaml"/>
-        <AdditionalFiles Include="Views\DownloadsView.axaml"/>
-        <AdditionalFiles Include="Views\DownloadView.axaml"/>
-        <AdditionalFiles Include="Views\InfoView.axaml"/>
-        <AdditionalFiles Include="Views\LoadingView.axaml"/>
-        <AdditionalFiles Include="Views\LogView.axaml"/>
-        <AdditionalFiles Include="Views\MainWindow.axaml"/>
-        <AdditionalFiles Include="Views\PreferencesView.axaml"/>
-        <AdditionalFiles Include="Views\SearchResultView.axaml"/>
-        <AdditionalFiles Include="Views\SearchView.axaml"/>
-        <AdditionalFiles Include="Views\SubOnlyView.axaml"/>
-        <AdditionalFiles Include="Views\UpdateInfoView.axaml"/>
-        <AdditionalFiles Include="Views\WelcomeView.axaml"/>
+        <AdditionalFiles Include="Views\AuthView.axaml" />
+        <AdditionalFiles Include="Views\DownloadsView.axaml" />
+        <AdditionalFiles Include="Views\DownloadView.axaml" />
+        <AdditionalFiles Include="Views\InfoView.axaml" />
+        <AdditionalFiles Include="Views\LoadingView.axaml" />
+        <AdditionalFiles Include="Views\LogView.axaml" />
+        <AdditionalFiles Include="Views\MainWindow.axaml" />
+        <AdditionalFiles Include="Views\PreferencesView.axaml" />
+        <AdditionalFiles Include="Views\SearchResultView.axaml" />
+        <AdditionalFiles Include="Views\SearchView.axaml" />
+        <AdditionalFiles Include="Views\SubOnlyView.axaml" />
+        <AdditionalFiles Include="Views\UpdateInfoView.axaml" />
+        <AdditionalFiles Include="Views\WelcomeView.axaml" />
     </ItemGroup>
 
     <ItemGroup>
@@ -158,13 +158,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\TwitchLeecher.Core\TwitchLeecher.Core.csproj"/>
-        <ProjectReference Include="..\TwitchLeecher.Services\TwitchLeecher.Services.csproj"/>
-        <ProjectReference Include="..\TwitchLeecher.Shared\TwitchLeecher.Shared.csproj"/>
+        <ProjectReference Include="..\TwitchLeecher.Core\TwitchLeecher.Core.csproj" />
+        <ProjectReference Include="..\TwitchLeecher.Services\TwitchLeecher.Services.csproj" />
+        <ProjectReference Include="..\TwitchLeecher.Shared\TwitchLeecher.Shared.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.0-beta1" />
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.2" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.0" />
         <PackageReference Include="Deadpikle.AvaloniaProgressRing" Version="0.10.8" />
         <PackageReference Include="Projektanker.Icons.Avalonia" Version="9.4.0" />

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadsView.axaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadsView.axaml
@@ -106,8 +106,8 @@
                                     </Grid.RowDefinitions>
 
                                     <TextBlock Grid.Column="0" Grid.Row="0" Text="Status:" FontWeight="Bold" />
-                                    <TextBlock Grid.Column="2" Grid.Row="0" Text="{Binding Status, Mode=TwoWay}"
-                                               FontWeight="Bold"
+                                    <TextBlock Grid.Column="2" Grid.Row="0" FontWeight="Bold"
+                                               Text="{Binding Status}"
                                                Foreground="{Binding DownloadState, Converter={StaticResource DownloadStateToColorConverter}}" />
 
                                     <TextBlock Grid.Column="0" Grid.Row="2" Text="Length:" FontWeight="Bold" />

--- a/TwitchLeecher/TwitchLeecher.Services/TwitchLeecher.Services.csproj
+++ b/TwitchLeecher/TwitchLeecher.Services/TwitchLeecher.Services.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>11.2.0-beta1</Version>
+      <Version>11.3.2</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>

--- a/TwitchLeecher/TwitchLeecher.Shared/TwitchLeecher.Shared.csproj
+++ b/TwitchLeecher/TwitchLeecher.Shared/TwitchLeecher.Shared.csproj
@@ -18,8 +18,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.0-beta1" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.2.0-beta1" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.2" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.2" />
     <PackageReference Include="Ninject" Version="4.0.0-beta.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.118" />

--- a/TwitchLeecher/TwitchLeecher/TwitchLeecher.csproj
+++ b/TwitchLeecher/TwitchLeecher/TwitchLeecher.csproj
@@ -11,13 +11,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.2.0-beta1" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.2.0-beta1" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.0-beta1" />
+        <PackageReference Include="Avalonia" Version="11.3.2" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.2" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.2" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.0-beta1" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.0-beta1" />
-        <PackageReference Include="Avalonia.Themes.Simple" Version="11.2.0-beta1" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.2" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.2" />
+        <PackageReference Include="Avalonia.Themes.Simple" Version="11.3.2" />
         <PackageReference Include="Deadpikle.AvaloniaProgressRing" Version="0.10.8" />
         <PackageReference Include="Projektanker.Icons.Avalonia" Version="9.4.0" />
         <PackageReference Include="Projektanker.Icons.Avalonia.FontAwesome" Version="9.4.0" />


### PR DESCRIPTION
It was not updating automatically because the relevant event did not tell anything that it was changed.

Fixes #64