### PR TITLE
Support for downloading DASH format VODs

### DIFF
--- a/TwitchLeecher/TwitchLeecher.Core/Models/DownloadParameters.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/DownloadParameters.cs
@@ -11,7 +11,8 @@ namespace TwitchLeecher.Core.Models
     public class DownloadParameters : BindableBase
     {
         private static readonly ImmutableHashSet<string> SupportedConversionFormats = ImmutableHashSet.Create(".mp4", ".mkv");
-
+        private static readonly ImmutableHashSet<string> SupportedNoConversionFormats = ImmutableHashSet.Create(".mp4", ".ts");
+        
         #region Fields
 
         private readonly TwitchVideo _video;
@@ -253,9 +254,9 @@ namespace TwitchLeecher.Core.Models
                 {
                     AddError(currentProperty, "Please specify a filename!");
                 }
-                else if (_disableConversion && !_filename.EndsWith(".ts", StringComparison.OrdinalIgnoreCase))
+                else if (_disableConversion && !SupportedNoConversionFormats.Contains(Path.GetExtension(_filename)))
                 {
-                    AddError(currentProperty, "Filename must end with '.ts'!");
+                    AddError(currentProperty, $"Filename must end with one of the supported formats: {string.Join(", ", SupportedNoConversionFormats)}");
                 }
                 else if (!_disableConversion && !SupportedConversionFormats.Contains(Path.GetExtension(_filename)))
                 {

--- a/TwitchLeecher/TwitchLeecher.Core/Models/TwitchPlaylist.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/TwitchPlaylist.cs
@@ -8,36 +8,33 @@ namespace TwitchLeecher.Core.Models
 {
     public class TwitchPlaylist : List<TwitchPlaylistPart>
     {
+        #region Constants
+
+        private static readonly char[] extinfSeparators = { ':', ',' };        
+
+        #endregion Constants
+        
         #region Static Methods
 
-        public static TwitchPlaylist Parse(string tempDir, string playlistStr, string urlPrefix)
-        {
-            TwitchPlaylist playlist = new TwitchPlaylist();
-
+        public static TwitchPlaylist Parse(string tempDir, string playlistStr, string urlPrefix) {
             List<string> lines = playlistStr.Split(new string[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).ToList();
 
-            for (int i = 0; i < lines.Count; i++)
-            {
-                string line = lines[i];
-
-                if (line.StartsWith("#EXT-X-VERSION", StringComparison.OrdinalIgnoreCase))
-                {
-                    int version = int.Parse(line.Substring(line.LastIndexOf(":") + 1).TrimEnd(), NumberStyles.Integer, CultureInfo.InvariantCulture);
-
-                    if (version == 4)
-                    {
-                        return ParseV4(tempDir, lines, urlPrefix);
-                    }
-                    else
-                    {
-                        return ParseV3(tempDir, lines, urlPrefix);
-                    }
-                }
+            string playlistVersionStr = lines.Find(line => line.Trim().StartsWith("#EXT-X-VERSION:")) ?? ":";
+            int playlistVersion = int.Parse(playlistVersionStr.Split(':')[1], NumberStyles.Integer, CultureInfo.InvariantCulture);
+            switch (playlistVersion) {
+                case 3:
+                    return ParseV3(tempDir, lines, urlPrefix);                            
+                case 4:
+                    return ParseV4(tempDir, lines, urlPrefix);
+                case 6:
+                    return ParseV6(tempDir, lines, urlPrefix);
+                default:
+                    // V3 parsing was the old default too
+                    return ParseV3(tempDir, lines, urlPrefix);
             }
-
-            return playlist;
         }
-
+        
+        // In use even at 2026.08.04 (https://www.twitch.tv/videos/2836855458, 1080p60)
         private static TwitchPlaylist ParseV3(string tempDir, List<string> lines, string urlPrefix)
         {
             TwitchPlaylist playlist = new TwitchPlaylist();
@@ -99,6 +96,50 @@ namespace TwitchLeecher.Core.Models
             if (!string.IsNullOrWhiteSpace(currentPartStr) && lengthBuffer > 0)
             {
                 playlist.Add(new TwitchPlaylistPart(lengthBuffer, urlPrefix + currentPartStr, Path.Combine(tempDir, partCounter.ToString("D8") + ".ts")));
+            }
+
+            return playlist;
+        }
+        
+        // Format for DASH streams (in use roughly from 2026.02.)
+        private static TwitchPlaylist ParseV6(string tempDir, List<string> lines, string urlPrefix) {
+            TwitchPlaylist playlist = new TwitchPlaylist();
+
+            for (int i = 0; i < lines.Count; i++) {
+                string line = lines[i];
+
+                // process init segment
+                if (line.StartsWith("#EXT-X-MAP:URI=")) {
+                    string segmentName = line.Split("=")[1];
+                    
+                    playlist.Add(new TwitchPlaylistPart(
+                        0, // review: not used anywhere?
+                        urlPrefix + segmentName, 
+                        Path.Combine(tempDir, segmentName))
+                    );
+                    
+                // content segments
+                } else if (line.StartsWith("#EXTINF", StringComparison.OrdinalIgnoreCase)) {
+                    string segmentName = lines[i + 1];
+                    double segmentLength = Math.Max(
+                        double.Parse(
+                            line.Split(extinfSeparators)[1],
+                            NumberStyles.Any, CultureInfo.InvariantCulture), 
+                        0);
+
+                    if (!segmentName.All(c => char.IsDigit(c) || char.IsLetter(c) || c == '.') || !segmentName.EndsWith(".mp4")) {
+                        // filter segment name to safe chars, and the known good extensions
+                        throw new ApplicationException("VOD playlist is V6, but contains unknown entries");
+                    }
+
+                    playlist.Add(new TwitchPlaylistPart(
+                        segmentLength, 
+                        urlPrefix + segmentName, 
+                        Path.Combine(tempDir, segmentName))
+                    );
+                    
+                    i++;
+                }
             }
 
             return playlist;

--- a/TwitchLeecher/TwitchLeecher.Core/Models/TwitchPlaylist.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/TwitchPlaylist.cs
@@ -110,7 +110,7 @@ namespace TwitchLeecher.Core.Models
 
                 // process init segment
                 if (line.StartsWith("#EXT-X-MAP:URI=")) {
-                    string segmentName = line.Split("=")[1];
+                    string segmentName = line.Split("=")[1].Trim('"');
                     
                     playlist.Add(new TwitchPlaylistPart(
                         0, // review: not used anywhere?

--- a/TwitchLeecher/TwitchLeecher.Services/Services/DownloadService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/DownloadService.cs
@@ -160,7 +160,7 @@ namespace TwitchLeecher.Services.Services
                             downloadId);
                         string ffmpegFile = _processingService.FFMPEGExe;
                         string concatFile = Path.Combine(tempDir,
-                            Path.GetFileNameWithoutExtension(downloadParams.FullPath) + ".ts");
+                            Path.GetFileNameWithoutExtension(downloadParams.FullPath));
                         string outputFile = downloadParams.FullPath;
 
                         bool disableConversion = downloadParams.DisableConversion;

--- a/TwitchLeecher/TwitchLeecher.Services/Services/DownloadService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/DownloadService.cs
@@ -159,11 +159,11 @@ namespace TwitchLeecher.Services.Services
                         string tempDir = Path.Combine(_preferencesService.CurrentPreferences.DownloadTempFolder,
                             downloadId);
                         string ffmpegFile = _processingService.FFMPEGExe;
-                        string concatFile = Path.Combine(tempDir,
-                            Path.GetFileNameWithoutExtension(downloadParams.FullPath));
+                        string concatFile = Path.Combine(tempDir, Path.GetFileName(downloadParams.FullPath));
                         string outputFile = downloadParams.FullPath;
 
-                        bool disableConversion = downloadParams.DisableConversion || concatFile.EndsWith(".mp4");
+                        bool skipConversion = concatFile.EndsWith(".mp4") && outputFile.EndsWith(".mp4");
+                        bool disableConversion = downloadParams.DisableConversion || skipConversion;
                         bool cropStart = downloadParams.CropStart;
                         bool cropEnd = downloadParams.CropEnd;
 

--- a/TwitchLeecher/TwitchLeecher.Services/Services/DownloadService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/DownloadService.cs
@@ -163,7 +163,7 @@ namespace TwitchLeecher.Services.Services
                             Path.GetFileNameWithoutExtension(downloadParams.FullPath));
                         string outputFile = downloadParams.FullPath;
 
-                        bool disableConversion = downloadParams.DisableConversion;
+                        bool disableConversion = downloadParams.DisableConversion || concatFile.EndsWith(".mp4");
                         bool cropStart = downloadParams.CropStart;
                         bool cropEnd = downloadParams.CropEnd;
 


### PR DESCRIPTION
Things to consider before merging, community input is welcome:
- DASH format VODs are downloaded in mp4. Do we need to keep the "Disable conversion to mp4" setting? In any case, its description is now inaccurate
- is the `length` property of `TwitchPlaylistPart` used anywhere? Just to ensure whether its fine to just have a part marked as 0 length

Fixes https://github.com/schneidermanuel/TwitchLeecher-Dx/issues/98